### PR TITLE
fix crashes when setting y_orign='bottom'

### DIFF
--- a/gizeh/gizeh.py
+++ b/gizeh/gizeh.py
@@ -290,7 +290,7 @@ class ImagePattern(Element):
 
     def __init__(self, image, pixel_zero=[0,0], filter="best", extend="none"):
         if isinstance(image, Surface):
-            self._cairo_surface = image
+            self._cairo_surface = image._cairo_surface
         else:
             self._cairo_surface = Surface.from_image(image)._cairo_surface
         self.matrix = translation_matrix(pixel_zero)


### PR DESCRIPTION
This fixes crashes I was getting when using y_origin 

e.g. surface.write_to_png("out.png", y_origin="bottom")

Might also be a fix for https://github.com/Zulko/gizeh/issues/14