### PR TITLE
ImagePattern explicit cast.

### DIFF
--- a/gizeh/gizeh.py
+++ b/gizeh/gizeh.py
@@ -49,7 +49,7 @@ class Surface:
             image = np.dstack([image, 255 * np.ones((h, w))])
         sf = Surface(w, h)
         arr = np.frombuffer(sf._cairo_surface.get_data(), np.uint8)
-        arr += image.flatten()
+        np.add(arr, image.flatten(), out=arr, casting="unsafe")
         sf._cairo_surface.mark_dirty()
         return sf
 


### PR DESCRIPTION
Explicit cast using np.add. Fixes a bug that causes ImagePattern not to work, due to dependency on deprecated numpy behaviour, as described in #25 