### PR TITLE
don't add transforms in shape_element() if not necessary

### DIFF
--- a/gizeh/gizeh.py
+++ b/gizeh/gizeh.py
@@ -439,6 +439,10 @@ def shape_element(draw_contour, xy=(0, 0), angle=0, fill=None, stroke=(0, 0, 0),
 
     if angle == 0 and xy == (0,0):
         return Element(new_draw)
+    elif angle == 0:
+        return Element(new_draw).translate(xy)
+    elif xy == (0,0)
+        return Element(new_draw).rotate(angle)
     else:
         return Element(new_draw).rotate(angle).translate(xy)
 

--- a/gizeh/gizeh.py
+++ b/gizeh/gizeh.py
@@ -437,7 +437,10 @@ def shape_element(draw_contour, xy=(0, 0), angle=0, fill=None, stroke=(0, 0, 0),
             _set_source(ctx, stroke)
             ctx.stroke_preserve()
 
-    return Element(new_draw).rotate(angle).translate(xy)
+    if angle == 0 and xy == (0,0):
+        return Element(new_draw)
+    else:
+        return Element(new_draw).rotate(angle).translate(xy)
 
 
 def rectangle(lx, ly, **kw):


### PR DESCRIPTION
shape_element() always rotates and translates even if both parameters are 0. This degrades performance for animations. 