### PR TITLE
Fix syntax error

### DIFF
--- a/gizeh/gizeh.py
+++ b/gizeh/gizeh.py
@@ -441,7 +441,7 @@ def shape_element(draw_contour, xy=(0, 0), angle=0, fill=None, stroke=(0, 0, 0),
         return Element(new_draw)
     elif angle == 0:
         return Element(new_draw).translate(xy)
-    elif xy == (0,0)
+    elif xy == (0,0):
         return Element(new_draw).rotate(angle)
     else:
         return Element(new_draw).rotate(angle).translate(xy)


### PR DESCRIPTION
The missing `:` here was causing compile errors. Also noticed that the version in PyPI is stale. Think this is a great wrapper over CFFI, and I love the simplicity of the API.