### PR TITLE
Replace 'cairocffi' by 'pycairo'

### DIFF
--- a/examples/roses.py
+++ b/examples/roses.py
@@ -7,7 +7,10 @@ http://en.wikipedia.org/wiki/Rose_mathematics
 
 import gizeh as gz
 import numpy as np
-from fractions import gcd
+try:
+    from fractions import gcd
+except ImportError:
+    from math import gcd
 
 def rose(d, n):
     """ Returns a polyline representing a rose of radius 1 """

--- a/gizeh/gizeh.py
+++ b/gizeh/gizeh.py
@@ -1,7 +1,7 @@
 from copy import copy, deepcopy
 from base64 import b64encode
 import numpy as np
-import cairocffi as cairo
+import cairo
 from .geometry import (rotation_matrix,
                        translation_matrix,
                        scaling_matrix,

--- a/setup.py
+++ b/setup.py
@@ -20,5 +20,5 @@ setup(name='gizeh',
     long_description=open('README.rst').read(),
     license='see LICENSE.txt',
     keywords="Cairo vector graphics",
-    install_requires=['cairocffi', 'numpy'],
+    install_requires=['pycairo>=1.20.0', 'numpy'],
     packages= find_packages(exclude='docs'))

--- a/setup.py
+++ b/setup.py
@@ -20,5 +20,5 @@ setup(name='gizeh',
     long_description=open('README.rst').read(),
     license='see LICENSE.txt',
     keywords="Cairo vector graphics",
-    install_requires=['pycairo>=1.20.0', 'numpy'],
+    install_requires=['pycairo', 'numpy'],
     packages= find_packages(exclude='docs'))


### PR DESCRIPTION
Following from discussion in https://github.com/Zulko/moviepy/issues/1472, this pull replaces `cairocffi` by [`pycairo`](https://pycairo.readthedocs.io/en/latest/index.html):

- I've tested manually (Ubuntu) all the examples in README and the `examples/` directory and works es expected. Some performance tests confirms that pycairo runs faster than cairocffi, because is written directly in C. 
- I've tested using [this workflow](https://github.com/mondeja/test-pycairo-windows/blob/main/.github/workflows/test.yml) all the examples in Windows and works with an standalone installation. You can download the resulted images from [here](https://github.com/mondeja/test-pycairo-windows/actions/runs/503639425) (below in the section "Artifacts"). As I said in the linked issue, the `.dll` for Windows is contained in [Pycairo wheels](https://pypi.org/project/pycairo/#files) since v1.20.0.
- The rest of most common operative systems [must install Cairo](https://pycairo.readthedocs.io/en/latest/getting_started.html) as usual.
- I've fixed an issue with `gcd` that has been deprecated from `fractions` module since Python3.5 and removed in Python3.9, in `roses.py` example.

So, this change brings:

- Standalone support for Windows.
- Performance increase.
- Example fix.